### PR TITLE
Use json instead of pipe-delimited for timeline outputFormat

### DIFF
--- a/cmd/cubic-cli/cmd/transcribe.go
+++ b/cmd/cubic-cli/cmd/transcribe.go
@@ -414,12 +414,10 @@ func transcribeFiles(workerID int, wg *sync.WaitGroup, client *cubic.Client,
 		// Create and send the Streaming Recognize config
 		err = client.StreamingRecognize(context.Background(),
 			&cubicpb.RecognitionConfig{
-				ModelId:               model,
-				AudioEncoding:         audioEncoding,
-				EnableWordTimeOffsets: true,
-				EnableRawTranscript:   true,
-				IdleTimeout:           &pbduration.Duration{Seconds: 30},
-				AudioChannels:         audioChannelsUint32,
+				ModelId:       model,
+				AudioEncoding: audioEncoding,
+				IdleTimeout:   &pbduration.Duration{Seconds: 30},
+				AudioChannels: audioChannelsUint32,
 			},
 			audio, // The file to send
 			func(response *cubicpb.RecognitionResponse) { // The callback for results

--- a/cmd/cubic-cli/cmd/transcribe.go
+++ b/cmd/cubic-cli/cmd/transcribe.go
@@ -418,10 +418,12 @@ func transcribeFiles(workerID int, wg *sync.WaitGroup, client *cubic.Client,
 		// Create and send the Streaming Recognize config
 		err = client.StreamingRecognize(context.Background(),
 			&cubicpb.RecognitionConfig{
-				ModelId:       model,
-				AudioEncoding: audioEncoding,
-				IdleTimeout:   &pbduration.Duration{Seconds: 30},
-				AudioChannels: audioChannelsUint32,
+				ModelId:               model,
+				AudioEncoding:         audioEncoding,
+				EnableWordTimeOffsets: true,
+				EnableRawTranscript:   true,
+				IdleTimeout:           &pbduration.Duration{Seconds: 30},
+				AudioChannels:         audioChannelsUint32,
 			},
 			audio, // The file to send
 			func(response *cubicpb.RecognitionResponse) { // The callback for results

--- a/cmd/cubic-cli/cmd/transcribe.go
+++ b/cmd/cubic-cli/cmd/transcribe.go
@@ -90,7 +90,7 @@ func init() {
 			"reasonable value.  A lower number is suggested if there are multiple \n"+
 			"clients connecting to the same machine.")
 
-	transcribeCmd.Flags().IntVarP(&maxAlternatives, "maxAlts", "a", 1,
+	transcribeCmd.Flags().IntVarP(&maxAlternatives, "fmt.timeline.maxAlts", "a", 1,
 		"Maximum number of alternatives to provide for each result, if the outputFormat includes alternatives (such as 'timeline').")
 }
 
@@ -425,6 +425,8 @@ func transcribeFiles(workerID int, wg *sync.WaitGroup, client *cubic.Client,
 		if outputFormat == "timeline" {
 			cfg.EnableWordConfidence = true
 			cfg.EnableWordTimeOffsets = true
+
+			//TODO(julie) Once we've updated cubicsvr so it can output formatted transcript and word-level features, remove this line
 			cfg.EnableRawTranscript = true
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cobaltspeech/cubic-cli
 go 1.12
 
 require (
-	github.com/cobaltspeech/sdk-cubic/grpc/go-cubic v1.0.1
+	github.com/cobaltspeech/sdk-cubic/grpc/go-cubic v1.1.0
 	github.com/golang/protobuf v1.3.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cobaltspeech/sdk-cubic/grpc/go-cubic v1.0.1 h1:m23AzPM3Q63ZBWuahdby0uiKkneQFSSrKiFqHh7OgSQ=
-github.com/cobaltspeech/sdk-cubic/grpc/go-cubic v1.0.1/go.mod h1:j4kQNxCaTD6Dhy+YM0Ci7MX+3Lsd1BRRm9g8MWqKsso=
+github.com/cobaltspeech/sdk-cubic/grpc/go-cubic v1.1.0 h1:bmzqTMIVFoGGN+RJb41KqoxUOxESTpzW4o46iU38OX0=
+github.com/cobaltspeech/sdk-cubic/grpc/go-cubic v1.1.0/go.mod h1:j4kQNxCaTD6Dhy+YM0Ci7MX+3Lsd1BRRm9g8MWqKsso=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/internal/formatters/results/timeline/formatter.go
+++ b/internal/formatters/results/timeline/formatter.go
@@ -13,9 +13,9 @@ import (
 
 // Alternative is a subset of the fields in cubicpb.RecognitionAlternative
 type Alternative struct {
-	StartTime  int
-	Confidence int
-	Transcript string
+	StartTime  int     `json:"start_time"`
+	Confidence float64 `json:"confidence"`
+	Transcript string  `json:"transcript"`
 }
 
 // Result encapsulates the Alternatives for a specific endpointed utterance
@@ -50,7 +50,7 @@ func Format(results []*cubicpb.RecognitionResult) string {
 
 			entry.Nbest = append(entry.Nbest, Alternative{
 				StartTime:  durToMs(alternative.StartTime),
-				Confidence: int(alternative.Confidence * 1000),
+				Confidence: alternative.Confidence,
 				Transcript: alternative.Transcript,
 			})
 		}

--- a/internal/formatters/results/timeline/formatter.go
+++ b/internal/formatters/results/timeline/formatter.go
@@ -1,4 +1,16 @@
-// Copyright (2019) Cobalt Speech and Language Inc.  All rights reserved.
+// Copyright (2019) Cobalt Speech and Language Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package timeline
 
@@ -20,6 +32,8 @@ type Alternative struct {
 }
 
 // MarshalJSON hides the unfriendly JSON output for duration.Duration
+// The pattern of aliasing the type we want to shadow is from the
+// blog post http://choly.ca/post/go-json-marshalling/
 func (a *Alternative) MarshalJSON() ([]byte, error) {
 	// create aliases so we have all the same fields but none of the methods and don't inherit the original type's MarshalJSON
 	type Alias Alternative
@@ -42,7 +56,6 @@ func (a *Alternative) MarshalJSON() ([]byte, error) {
 			Duration:  durToMs(word.Duration),
 			WordAlias: (*WordAlias)(word),
 		})
-
 	}
 	return json.Marshal(out)
 }
@@ -72,7 +85,6 @@ func (cfg Config) CreateFormatter() (ResultFormatter, error) {
 }
 
 func verifyCfg(cfg Config) error {
-
 	if cfg.MaxAlternatives < 1 {
 		return fmt.Errorf("Number of alternatives must be 1 or more")
 	}

--- a/internal/formatters/results/timeline/formatter_test.go
+++ b/internal/formatters/results/timeline/formatter_test.go
@@ -1,4 +1,16 @@
-// Copyright (2019) Cobalt Speech and Language Inc.  All rights reserved.
+// Copyright (2019) Cobalt Speech and Language Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package timeline_test
 
@@ -25,61 +37,58 @@ func TestExxonFormatter_Order(t *testing.T) {
 		newResult("partials are ignored", 1500, 0, true), // Shouldn't show up as a partial result.
 		newResult("", 1500, 0, false),                    // Shouldn't show up with an empty transcript.
 	}
-
-	wantStr := `[
+	want := []timeline.Result{
 		{
-		  "ChannelID": 0,
-		  "Nbest": [
-			{
-			  "start_time": 500,
-			  "confidence": 0.6,
-			  "transcript": "One0"
-			}
-		  ]
+			ChannelID: 0,
+			Nbest: []timeline.Alternative{
+				{
+					StartTime:  500,
+					Confidence: 0.6,
+					Transcript: "One0",
+				},
+			},
 		},
 		{
-		  "ChannelID": 1,
-		  "Nbest": [
-			{
-			  "start_time": 500,
-			  "confidence": 0.6,
-			  "transcript": "One1"
-			}
-		  ]
+			ChannelID: 1,
+			Nbest: []timeline.Alternative{
+				{
+					StartTime:  500,
+					Confidence: 0.6,
+					Transcript: "One1",
+				},
+			},
 		},
 		{
-		  "ChannelID": 0,
-		  "Nbest": [
-			{
-			  "start_time": 500,
-			  "confidence": 0.6,
-			  "transcript": "One0.1"
-			}
-		  ]
+			ChannelID: 0,
+			Nbest: []timeline.Alternative{
+				{
+					StartTime:  500,
+					Confidence: 0.6,
+					Transcript: "One0.1",
+				},
+			},
 		},
 		{
-		  "ChannelID": 1,
-		  "Nbest": [
-			{
-			  "start_time": 750,
-			  "confidence": 0.6,
-			  "transcript": "Two"
-			}
-		  ]
+			ChannelID: 1,
+			Nbest: []timeline.Alternative{
+				{
+					StartTime:  750,
+					Confidence: 0.6,
+					Transcript: "Two",
+				},
+			},
 		},
 		{
-		  "ChannelID": 0,
-		  "Nbest": [
-			{
-			  "start_time": 7500,
-			  "confidence": 0.6,
-			  "transcript": "Three"
-			}
-		  ]
-		}
-	]`
-	var want []timeline.Result
-	json.Unmarshal([]byte(wantStr), &want)
+			ChannelID: 0,
+			Nbest: []timeline.Alternative{
+				{
+					StartTime:  7500,
+					Confidence: 0.6,
+					Transcript: "Three",
+				},
+			},
+		},
+	}
 
 	cfg := timeline.Config{
 		MaxAlternatives: 1,
@@ -101,7 +110,6 @@ func TestExxonFormatter_Order(t *testing.T) {
 		t.Errorf("Error unmarshalling formatted result: %s", err)
 	}
 
-	// Test for either of the two possible answers.
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Unexpected output.\nGot:\n%v\n\nWant:\n%v\n\n", got, want)
 	}


### PR DESCRIPTION
* New flag to specify max number of alternatives per result
* Does not include the cnet
* Format duration.Duration as number of ms rather than a struct with seconds and nanoseconds
