### PR TITLE
Rework++

### DIFF
--- a/cmd/cubic-cli/cmd/root.go
+++ b/cmd/cubic-cli/cmd/root.go
@@ -80,7 +80,7 @@ func createClient() (*cubic.Client, error) {
 
 // verbosePrintf is a helper function.  Use --verbose to allow these strings to be printed
 func verbosePrintf(w io.Writer, format string, a ...interface{}) {
-	if verbose && w == os.Stderr {
+	if verbose {
 		fmt.Fprintf(w, "DEBUG: "+format, a...)
 	}
 }

--- a/cmd/cubic-cli/cmd/transcribe.go
+++ b/cmd/cubic-cli/cmd/transcribe.go
@@ -208,8 +208,7 @@ func statsPath(path string) (isFolder, exists bool, err error) {
 		}
 		return false, false, err
 	}
-	mode := fi.Mode()
-	return mode.IsDir(), true, nil
+	return fi.Mode().IsDir(), true, nil
 }
 
 // transcribe is the main function.

--- a/cmd/cubic-cli/cmd/transcribe.go
+++ b/cmd/cubic-cli/cmd/transcribe.go
@@ -63,18 +63,18 @@ func init() {
 
 	transcribeCmd.Flags().BoolVarP(&listFile, "list-file", "l", false, ""+
 		"When true, the FILE_PATH is pointing to a file containing a list of \n"+
-		"\"UtteranceID \\t path/to/audio.wav\", one entry per line.")
+		"  \"UtteranceID \\t path/to/audio.wav\", one entry per line.")
 
 	transcribeCmd.Flags().StringVarP(&resultsPath, "output", "o", "-", ""+
 		"Path to where the results should be written to.\n"+
-		"In single file mode, this path should be a file.\n"+
-		"In list file mode, this path should be a directory.  Each file processed will\n"+
-		"  have a separate output file, using the imput file's name, with a .txt extention.\n"+
-		"\"-\" indicates stdout in either case.  In list file mode, each entry will be \n"+
-		"  prefaced by the utterance ID and have an extra newline seperating it from the next. ")
+		"This path should be a directory.\n"+
+		"In --list-file mode, each file processed will have a separate output file, \n"+
+		"  using the utteranceID as the filename with a \".txt\" extention.\n"+
+		"\"-\" indicates stdout in either case.  In --list-file mode, each entry will be \n"+
+		"  prefaced by the utterance ID and have an extra newline seperating it from the next.")
 
 	transcribeCmd.Flags().StringVarP(&outputFormat, "outputFormat", "f", "timeline",
-		"Format of output.  Can be [json,utterance-json,json-pretty,timeline].")
+		"Format of output.  Can be [json,json-pretty,timeline,utterance-json].")
 
 	transcribeCmd.Flags().IntSliceVarP(&audioChannels, "audioChannels", "c", []int{}, ""+
 		"Audio channels to transcribe.  Defaults to mono.\n"+
@@ -84,19 +84,20 @@ func init() {
 		"Overrides --stereo if both are included.")
 
 	transcribeCmd.Flags().BoolVar(&audioChannelsStereo, "stereo", false, ""+
-		"Sets --audioChannels \"0,1\" which transcribes both audio channels of a stereo file.\n"+
+		"Sets --audioChannels \"0,1\" to transcribe both audio channels of a stereo file.\n"+
 		"If --audioChannels is set, this flag is ignored.")
 
 	transcribeCmd.Flags().IntVarP(&nConcurrentRequests, "workers", "n", 1, ""+
 		"Number of concurrent requests to send to cubicsvr.\n"+
-		"Please note, while this value is defined client-side the performance \n"+
-		"will be limited by the available computational ability of the server.  \n"+
-		"If you are the only connection to an 8-core server, then \"-n 8\" is a \n"+
-		"reasonable value.  A lower number is suggested if there are multiple \n"+
+		"Please note, while this value is defined client-side the performance\n"+
+		"will be limited by the available computational ability of the server.\n"+
+		"If you are the only connection to an 8-core server, then \"-n 8\" is a\n"+
+		"reasonable value.  A lower number is suggested if there are multiple\n"+
 		"clients connecting to the same machine.")
 
-	transcribeCmd.Flags().IntVarP(&maxAlternatives, "fmt.timeline.maxAlts", "a", 1,
-		"Maximum number of alternatives to provide for each result, if the outputFormat includes alternatives (such as 'timeline').")
+	transcribeCmd.Flags().IntVarP(&maxAlternatives, "fmt.timeline.maxAlts", "a", 1, ""+
+		"Maximum number of alternatives to provide for each result, if the outputFormat\n"+
+		"includes alternatives (such as 'timeline').")
 
 }
 
@@ -125,8 +126,8 @@ The file extension (wav, flac, mp3, vox, raw) will be used to determine which
 Summary of "--outputFormat" options:
     * json           - json of map[uttID][]Results.
     * json-pretty    - json of map[uttID][]Results, prettified with newlines and indents.
-    * utterance-json - "UttID_SegID \t json of a single Result", grouped by UttID.
     * timeline       - "start_time|channel_id|1best transcript", grouped by UttID.
+    * utterance-json - "UttID_SegID \t json of a single Result", grouped by UttID.
 
 See "transcribe --help" for details on the other flags.`
 

--- a/cmd/cubic-cli/cmd/transcribe.go
+++ b/cmd/cubic-cli/cmd/transcribe.go
@@ -393,7 +393,7 @@ func loadListFiles(path string) ([]inputs, error) {
 			}
 		}
 
-		// Generate an outputWriter for each file
+		// Generate an output file for each input file
 		var outputPath = "-"
 		if resultsPath != "-" {
 			outputPath = filepath.Join(resultsPath, id+"_results.txt")
@@ -509,7 +509,6 @@ func transcribeFiles(workerID int, wg *sync.WaitGroup, client *cubic.Client,
 		if outputFormat == "timeline" {
 			cfg.EnableWordConfidence = true
 			cfg.EnableWordTimeOffsets = true
-
 		}
 
 		// create buffer for file's results


### PR DESCRIPTION
This commit cleans up a little bit of the output formats, but introduces a little bit more complexity around that.  (Part of me wonders if we could simplify some of this by moving to separate sub commands for list and single file).  Let me know what you think about the outputWriter changes, specifically where/when we create the output file, and how we pass it around.

It should resolve #4, #14, and #15.  I apologize for not fixing them in separate PRs.